### PR TITLE
Fix docker build

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,0 @@
-https://github.com/heroku/heroku-buildpack-nodejs.git#v175
-https://github.com/heroku/heroku-buildpack-apt
-https://github.com/heroku/heroku-buildpack-php

--- a/Aptfile
+++ b/Aptfile
@@ -1,2 +1,0 @@
-libonig-dev
-libonig4

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: vendor/bin/heroku-php-nginx -C nginx_app.conf public/

--- a/nginx_app.conf
+++ b/nginx_app.conf
@@ -1,14 +1,25 @@
-location / {
-    # try to serve file directly, fallback to rewrite
-    try_files $uri @rewriteapp;
-}
+server {
+    listen 8000 default_server;
+    listen [::]:8000 default_server;
 
-location @rewriteapp {
-    # rewrite all to index.php
-    rewrite ^(.*)$ /index.php last;
-}
+    root /app/public;
 
-location ~ ^/index\.php(/|$) {
-    try_files @heroku-fcgi @heroku-fcgi;
-    internal;
+    location / {
+        try_files $uri /index.php?$args;
+    }
+
+    location ~ ^/index\.php(/|$) {
+        fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+        if (!-f $document_root$fastcgi_script_name) {
+            return 404;
+        }
+
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO       $fastcgi_path_info;
+        fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
+
+        fastcgi_pass   localhost:9000;
+        fastcgi_index  index.php;
+    }
 }

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+su www -c 'php artisan config:cache'
+su www -c 'php artisan migrate --force'
+
+su www -c 'php-fpm7 -F' &
+nginx -g 'daemon off;' &
+
+wait -n
+exit $?
+
+# This scripts starts both php-fpm and nginx. If one exits, it kills the other
+# one and exits, stopping the container (which could then be restarted)


### PR DESCRIPTION
Forgot some stuff used in prod :skull:. The `compose.yaml`-file overrides the command in the container to run `php artisan serve` instead of `run.sh`, so without this fix, it does not run in dokku or if you do `docker build` and `docker run` manually.